### PR TITLE
splitbelow and splitright to get the correct canvas layout

### DIFF
--- a/bmc.vim
+++ b/bmc.vim
@@ -12,32 +12,39 @@
 " - To edit your BMC type ``vim -S bmc.vim``
 " - To save all your changes type ``:wa``
 " - To quit your BMC type ``:qa``
-"
+
 
 " Setup the window layout
 
-" Key Partners
+"" Put new windows below and to the right
+setlocal splitbelow
+setlocal splitright
+
+"" Key Partners
 edit partners.md
 
-" Key Activities
+"" Key Activities
 vertical split activities.md
-" Key Resources
+
+"" Key Resources
 split resources.md
 
-" Value Propositions
+"" Value Propositions
 botright vertical split values.md
 
-" Customer Relationships
+"" Customer Relationships
 vertical split relationships.md
-" Channels
+
+"" Channels
 split channels.md
 
-" Customer Segments
+"" Customer Segments
 botright vertical split segments.md
 
-" Cost Structure
+"" Cost Structure
 botright split costs.md
-" Revenue Stream
+
+"" Revenue Stream
 vertical split revenues.md
 
 

--- a/bmc.vim
+++ b/bmc.vim
@@ -3,15 +3,15 @@
 " Business Model Canvas
 " =====================
 "
-" Enjoy iterating your kickass business model with the help of an kickass text
+" Enjoy iterating your kickass business model with the help of a kickass text
 " editor under the version control system of your choice. Good Luck!
 "
 "
 " Usage:
 "
-" - To edit your BMC type ``vim -S bmc.vim``
-" - To save all your changes type ``:wa``
-" - To quit your BMC type ``:qa``
+" - To edit your BMC, type ``vim -S bmc.vim``
+" - To save all your changes, type ``:wa``
+" - To quit your BMC, type ``:qa``
 
 
 " Setup the window layout
@@ -48,16 +48,18 @@ botright split costs.md
 vertical split revenues.md
 
 
-" Turn of line numbers in each window (free up space)
+" Turn off line numbers in each window (free up space)
 windo setlocal nonumber
 
-" Turn line wrapping of (looks bad in narrow windows)
+
+" Turn line wrapping off (looks bad in narrow windows)
 windo setlocal nowrap
 
-" TODO: Place cursor on upper right window
+
+" Place cursor on upper left window
 wincmd h
 wincmd k
 
+
 " Spread windows equally across screen
 wincmd =
-

--- a/revenues.md
+++ b/revenues.md
@@ -1,4 +1,4 @@
-# Revenue Stream
+# Revenue Streams
 
 - For what value are our customers really willing to pay?
 - For what do they currently pay?

--- a/values.md
+++ b/values.md
@@ -1,4 +1,4 @@
-# Value Propositions
+# Value Proposition
 
 - What value do we deliver to the customer?
 - Which one of our customer's problems are we helping to solve?


### PR DESCRIPTION
By default, a vertical split opens the new window above and a horizontal split opens the new window to the left. This throws off the business model canvas layout. This pull request corrects this. It also addresses minor comment and header typos.